### PR TITLE
Allow for a custom graphql client in any test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,16 +4,23 @@ import './index.css'
 import App from './App'
 import { GraphqlProvider, graphqlClient } from './graphql'
 
-if (process.env.NODE_ENV === 'development') {
-  const { worker } = require('./mocks/browser')
-  worker.start()
+function renderApp() {
+  return ReactDOM.render(
+    <React.StrictMode>
+      <GraphqlProvider value={graphqlClient}>
+        <App />
+      </GraphqlProvider>
+    </React.StrictMode>,
+    document.getElementById('root')
+  )
 }
 
-ReactDOM.render(
-  <React.StrictMode>
-    <GraphqlProvider value={graphqlClient}>
-      <App />
-    </GraphqlProvider>
-  </React.StrictMode>,
-  document.getElementById('root')
-)
+if (process.env.NODE_ENV === 'development') {
+  // If you end up with a component that fetches on mount, 
+  // this ensures that `msw` has started and prevents
+  // a possible race condition for some users/browsers
+  const { worker } = require('./mocks/browser')
+  worker.start().then(() => renderApp())
+} 
+
+renderApp();

--- a/src/utils/testutils.js
+++ b/src/utils/testutils.js
@@ -1,21 +1,28 @@
-import React from 'react'
-import { render as renderFn } from '@testing-library/react'
-import { renderHook } from '@testing-library/react-hooks'
-import { GraphqlProvider, graphqlClient } from '../graphql'
+import React from "react";
+import { render as renderFn } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks";
+import {
+  GraphqlProvider,
+  graphqlClient as defaultGraphqlClient,
+} from "../graphql";
 
-function Providers({ children }) {
+function Providers({ children, graphqlClient = defaultGraphqlClient }) {
   return (
     <React.StrictMode>
-      <GraphqlProvider value={graphqlClient}>
-        {children}
-      </GraphqlProvider>
+      <GraphqlProvider value={graphqlClient}>{children}</GraphqlProvider>
     </React.StrictMode>
-  )
+  );
 }
 
 function render(ui, options = {}) {
-  return renderFn(ui, { wrapper: Providers, options })
+  const { graphqlClient } = options;
+  return renderFn(ui, {
+    wrapper: graphqlClient
+      ? ({ children }) => Providers({ children, graphqlClient })
+      : Providers,
+    options,
+  });
 }
 
-export * from '@testing-library/react'
-export { render, renderHook }
+export * from "@testing-library/react";
+export { render, renderHook };


### PR DESCRIPTION
Fixes the caching issue in tests for graphql requests by allowing a test to take in a custom `graphqlClient` on a per-test basis.